### PR TITLE
Fix null handling in ingestion and simulation services

### DIFF
--- a/src/core-api/Services/MycosoftIntegrationService.cs
+++ b/src/core-api/Services/MycosoftIntegrationService.cs
@@ -286,6 +286,10 @@ public class MycosoftIntegrationService : IMycosoftIntegrationService
 
             simResponse.EnsureSuccessStatusCode();
             var simResult = await simResponse.Content.ReadFromJsonAsync<MyceliumSimResult>(cancellationToken);
+            if (simResult == null)
+            {
+                throw new InvalidOperationException("Simulation service returned no result");
+            }
 
             // Store results in MINDEX
             await StoreSimulationResultAsync(simResult);

--- a/src/ingestion/Program.cs
+++ b/src/ingestion/Program.cs
@@ -31,9 +31,14 @@ var host = new HostBuilder()
 
         services.AddSingleton(provider =>
         {
-            var endpoint = configuration.GetConnectionString("EventGridConnectionString") ?? 
+            var endpoint = configuration.GetConnectionString("EventGridConnectionString") ??
                            configuration["EventGridConnectionString"];
-            var key = configuration["EventGridKey"] ?? "";
+            if (string.IsNullOrWhiteSpace(endpoint))
+            {
+                throw new InvalidOperationException("EventGrid connection string is not configured");
+            }
+
+            var key = configuration["EventGridKey"] ?? string.Empty;
             return new EventGridPublisherClient(new Uri(endpoint), new AzureKeyCredential(key));
         });
 


### PR DESCRIPTION
## Summary
- add check for EventGrid connection string in ingestion service
- validate simulation results in Mycosoft integration service

## Testing
- `dotnet build NatureOS.sln`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6885c85015c8832a8073b3c2312d787a

## Summary by Sourcery

Improve null handling and validation in the ingestion and simulation services

Bug Fixes:
- Validate presence of EventGrid connection string and throw an error if missing in the ingestion service
- Check for null simulation results and throw an error if the Mycosoft integration service returns no result