### PR TITLE
Use SignalR for website live updates

### DIFF
--- a/website-integration/components/LiveDataComponent.jsx
+++ b/website-integration/components/LiveDataComponent.jsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
+import { HubConnectionBuilder, LogLevel } from '@microsoft/signalr';
 
 export default function LiveDataComponent() {
   const [liveData, setLiveData] = useState(null);
@@ -29,11 +30,42 @@ export default function LiveDataComponent() {
     }
   }, []);
 
-  // Set up real-time updates
+  // Set up real-time updates via SignalR
   useEffect(() => {
-    fetchLiveData();
-    const interval = setInterval(fetchLiveData, 5000); // Update every 5 seconds
-    return () => clearInterval(interval);
+    // Create SignalR connection to NatureOS hub
+    const connection = new HubConnectionBuilder()
+      .withUrl('/natureos-hub')
+      .withAutomaticReconnect()
+      .configureLogging(LogLevel.Information)
+      .build();
+
+    const startConnection = async () => {
+      try {
+        await connection.start();
+        setIsConnected(true);
+
+        // Join dashboard group to receive updates
+        await connection.invoke('JoinDashboardGroup');
+
+        // Fetch initial data once connected
+        await fetchLiveData();
+
+        // Refresh data when the server signals updates
+        connection.on('DeviceUpdate', fetchLiveData);
+        connection.on('SimulationUpdate', fetchLiveData);
+        connection.on('SystemUpdate', fetchLiveData);
+        connection.onclose(() => setIsConnected(false));
+      } catch (err) {
+        setError(err.message);
+        setIsConnected(false);
+      }
+    };
+
+    startConnection();
+
+    return () => {
+      connection.stop();
+    };
   }, [fetchLiveData]);
 
   if (!liveData) {


### PR DESCRIPTION
## Summary
- Switch website integration's `LiveDataComponent` to use SignalR rather than interval polling
- Join the dashboard update group and refresh data on server events

## Testing
- `dotnet build NatureOS.sln` *(fails: IProactiveMonitoringService not found)*
- `npm test` in `website-integration` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689654e63724832ab03aea8115d85d36