### PR TITLE
security: CVE-2026-31431 (Copy Fail) mitigation bundle [HIGH PRIORITY]

### DIFF
--- a/.github/workflows/cve-2026-31431-runner-precheck.yml
+++ b/.github/workflows/cve-2026-31431-runner-precheck.yml
@@ -1,0 +1,19 @@
+name: cve-2026-31431-runner-precheck
+on:
+  workflow_call: {}
+  workflow_dispatch: {}
+jobs:
+  kernel-precheck:
+    runs-on: self-hosted
+    steps:
+      - name: Refuse to run on unpatched runners
+        shell: bash
+        run: |
+          set -euo pipefail
+          if lsmod | awk '{print $1}' | grep -qx algif_aead; then
+            echo "::error::algif_aead loaded -- CVE-2026-31431."; exit 1
+          fi
+          if ! grep -rqE '^install\\s+algif_aead\\s+/bin/false' /etc/modprobe.d/ 2>/dev/null; then
+            echo "::error::CVE-2026-31431 mitigation not applied."; exit 1
+          fi
+          echo runner-precheck ok

--- a/docs/security/cve-2026-31431-report.md
+++ b/docs/security/cve-2026-31431-report.md
@@ -1,0 +1,88 @@
+# CVE-2026-31431 ("Copy Fail") -- mitigation & adjacent-issue report
+
+**Repo scope:** `mycosoftlabs/natureos`
+**Status:** mitigation artifacts staged; host rollout via Ansible pending operator action.
+
+## 1. Why this repo matters most
+
+NatureOS is the platform layer -- hosts here run:
+- Cloud Shell (browser-based shell -> arbitrary user code on shared hosts)
+- Containers / Functions / sandbox runtimes (multi-tenant by design)
+- API Gateway nodes (84+ routes, internet-facing)
+- Ground Station / SporeBase ingest
+
+This is the highest blast-radius surface for CVE-2026-31431 in the org: a
+shell-tenant or sandbox-tenant can escape to host root on any unpatched node.
+
+## 2. Vulnerability
+
+| Field | Value |
+|---|---|
+| CVE | CVE-2026-31431 |
+| Nickname | Copy Fail |
+| Class | Linux kernel LPE -> container escape |
+| Root cause | 2017 in-place optimisation in `algif_aead` |
+| Primitive | 4-byte page-cache write via AF_ALG + splice() |
+| Affected | All mainstream Linux distros, kernels 4.14+ pre-fix |
+| Disclosed | 2026-04-29 (Theori) |
+| Upstream fix | mainline `a664bf3d603d` -- VERIFY on kernel.org |
+
+## 3. What this PR adds
+
+See `scripts/security/`, `ops/ansible/`, `ops/k8s/`,
+`.github/workflows/cve-2026-31431-runner-precheck.yml`,
+`scripts/ci/runner-precheck.sh`.
+
+## 4. Rollout checklist (HIGH PRIORITY for this repo)
+
+- [ ] Verify upstream commit `a664bf3d603d` on kernel.org / distro tracker.
+- [ ] Patch / reboot **every** NatureOS node before re-enabling Cloud Shell tenants.
+- [ ] Apply the Kyverno policy to all clusters running Functions, sandboxes, or notebooks.
+- [ ] Distribute the seccomp profile to all node `/var/lib/kubelet/seccomp/`.
+- [ ] Load Falco rules into the cluster-wide DaemonSet -- AF_ALG hits should page the SOC.
+- [ ] Install `runner-precheck.sh` on every self-hosted GH Actions runner.
+- [ ] Add `cve-2026-31431-detect.sh` to NatureOS node health probes; nodes failing the probe must be cordoned automatically.
+- [ ] Pause Cloud Shell / sandbox / notebook tenants until all backing nodes report mitigated.
+
+## 5. Adjacent-issue audit (this repo)
+
+| Pattern | Hits | Notes |
+|---|---|---|
+| `AF_ALG`, `algif`, `algif_aead` | 0 | No app code touches the vulnerable interface. |
+| `splice`, `vmsplice` in C/Py/Go/Rust | 0 | No userland splice callers. |
+| `privileged: true` | 0 | No privileged-container manifests surfaced. |
+| `hostNetwork`/`hostPID`/`hostIPC` | 0 | No host-namespace pods surfaced. |
+| `SYS_MODULE`/`CAP_SYS_ADMIN` | 0 | No capability-elevating manifests surfaced. |
+| `USER root` in Dockerfile | 0 | No explicit root-Dockerfile pattern. |
+
+No direct application-code exposure detected, but the **tenant surface**
+(Cloud Shell, Functions, sandboxes) means even mitigated nodes warrant the
+seccomp + Falco layers on top.
+
+## 6. Related CVEs to track
+
+- CVE-2022-0847 (Dirty Pipe) -- same page-cache class.
+- CVE-2022-2602 (io_uring + unix GC).
+- CVE-2023-32233, CVE-2024-1086 (nf_tables LPEs).
+- Historical `algif_*` bugs -- blocked by this PR's modprobe block.
+
+## 7. Hardening recommendations
+
+1. Permanently block `algif_*` org-wide. No NatureOS workload needs it.
+2. Treat the seccomp profile as **required**, not advisory, for any Pod that runs untrusted user code (Cloud Shell, Functions, sandboxes, notebooks).
+3. Add a Kubernetes admission webhook that refuses to schedule untrusted workloads onto nodes whose `cve-2026-31431-detect.sh` probe failed within the last 5 minutes.
+4. SOC dashboard subscribes to Falco AF_ALG events.
+5. Build the modprobe block into the NatureOS node base image so a wiped / re-imaged node starts mitigated.
+
+## 8. Verification
+
+```bash
+sudo bash scripts/security/cve-2026-31431-mitigate.sh
+bash scripts/security/cve-2026-31431-detect.sh && echo MITIGATED
+kubectl apply -f ops/k8s/cve-2026-31431-kyverno-policy.yaml
+```
+
+## 9. Caveats
+
+- `a664bf3d603d` taken from disclosure post; NOT independently verified.
+- Cloud Shell / sandbox tenant pause is an operational call, not automated by this PR.

--- a/ops/ansible/cve-2026-31431.yml
+++ b/ops/ansible/cve-2026-31431.yml
@@ -1,0 +1,35 @@
+---
+- name: Mitigate CVE-2026-31431 (Copy Fail) across NatureOS hosts
+  hosts: all
+  become: true
+  vars:
+    algif_modules: [algif_aead, algif_hash, algif_skcipher, algif_rng]
+  tasks:
+    - name: Persist modprobe block for algif_*
+      ansible.builtin.copy:
+        dest: /etc/modprobe.d/disable-algif.conf
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          {% for m in algif_modules %}
+          install {{ m }} /bin/false
+          {% endfor %}
+      notify: rebuild initramfs
+    - name: Unload algif_* if loaded
+      community.general.modprobe:
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ algif_modules }}"
+      failed_when: false
+    - name: Record marker
+      ansible.builtin.copy:
+        dest: /var/lib/cve-2026-31431.applied
+        content: "{{ ansible_date_time.iso8601 }}\n"
+        mode: "0644"
+  handlers:
+    - name: rebuild initramfs
+      ansible.builtin.shell: |
+        if command -v update-initramfs >/dev/null 2>&1; then update-initramfs -u
+        elif command -v dracut >/dev/null 2>&1; then dracut --force
+        fi

--- a/ops/k8s/cve-2026-31431-falco-rules.yaml
+++ b/ops/k8s/cve-2026-31431-falco-rules.yaml
@@ -1,0 +1,15 @@
+---
+- macro: af_alg_socket
+  condition: (evt.type=socket and evt.arg.domain=AF_ALG)
+- rule: AF_ALG socket created
+  desc: CVE-2026-31431 primitive.
+  condition: af_alg_socket and not proc.name in (cryptsetup, systemd-cryptsetup)
+  output: AF_ALG socket created (user=%user.name proc=%proc.name cmdline=%proc.cmdline)
+  priority: CRITICAL
+  tags: [cve-2026-31431]
+- rule: splice from AF_ALG fd
+  desc: Copy Fail page-cache write primitive.
+  condition: evt.type=splice and (fd.type=alg or fd.l4proto=alg)
+  output: splice() from AF_ALG fd (proc=%proc.name cmdline=%proc.cmdline)
+  priority: CRITICAL
+  tags: [cve-2026-31431]

--- a/ops/k8s/cve-2026-31431-kyverno-policy.yaml
+++ b/ops/k8s/cve-2026-31431-kyverno-policy.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata: { name: cve-2026-31431-require-af-alg-seccomp }
+spec:
+  validationFailureAction: Enforce
+  background: true
+  rules:
+    - name: require-block-af-alg-seccomp
+      match: { any: [{resources: {kinds: ["Pod"]}}] }
+      exclude: { any: [{resources: {namespaces: ["kube-system"]}}] }
+      validate:
+        message: Pods must use seccomp profile block-af-alg.json (CVE-2026-31431).
+        pattern:
+          spec:
+            securityContext:
+              seccompProfile: { type: Localhost, localhostProfile: block-af-alg.json }
+    - name: forbid-host-namespaces
+      match: { any: [{resources: {kinds: ["Pod"]}}] }
+      validate:
+        message: hostNetwork/hostPID/hostIPC widen CVE-2026-31431 blast radius.
+        pattern:
+          spec:
+            =(hostNetwork): "false"
+            =(hostPID): "false"
+            =(hostIPC): "false"

--- a/ops/k8s/seccomp/block-af-alg.json
+++ b/ops/k8s/seccomp/block-af-alg.json
@@ -1,0 +1,12 @@
+{
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "syscalls": [
+    {
+      "names": ["socket", "socketpair"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 1,
+      "args": [{ "index": 0, "value": 38, "op": "SCMP_CMP_EQ" }],
+      "comment": "Deny AF_ALG -- CVE-2026-31431"
+    }
+  ]
+}

--- a/scripts/ci/runner-precheck.sh
+++ b/scripts/ci/runner-precheck.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if lsmod | awk '{print $1}' | grep -qx algif_aead; then
+    echo "[abort] algif_aead loaded -- runner unpatched (CVE-2026-31431)"; exit 1
+fi
+if ! grep -rqE '^install\s+algif_aead\s+/bin/false' /etc/modprobe.d/ 2>/dev/null; then
+    echo "[abort] CVE-2026-31431 mitigation not present"; exit 1
+fi
+exit 0

--- a/scripts/security/cve-2026-31431-detect.sh
+++ b/scripts/security/cve-2026-31431-detect.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -uo pipefail
+status=0; note() { printf '%s\n' "$*" >&2; }
+note "kernel: $(uname -r)"
+if grep -rqE '^install\s+algif_aead\s+/bin/false' /etc/modprobe.d/ 2>/dev/null; then
+    note "[ok] modprobe block present"
+else note "[!] no modprobe block"; status=1; fi
+if lsmod 2>/dev/null | awk '{print $1}' | grep -qx algif_aead; then
+    note "[!] algif_aead loaded"; status=1; fi
+if command -v python3 >/dev/null 2>&1; then
+    python3 - <<'PY'
+import socket, sys
+try:
+    s = socket.socket(38, socket.SOCK_SEQPACKET, 0); s.close()
+    print("[!] AF_ALG socket creation succeeded"); sys.exit(3)
+except OSError as e:
+    print(f"[ok] AF_ALG blocked: {e}"); sys.exit(0)
+PY
+    [[ $? -eq 3 ]] && status=1
+fi
+exit ${status}

--- a/scripts/security/cve-2026-31431-mitigate.sh
+++ b/scripts/security/cve-2026-31431-mitigate.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# CVE-2026-31431 ("Copy Fail") host-level mitigation.
+set -euo pipefail
+if [[ "${EUID}" -ne 0 ]]; then echo "must run as root" >&2; exit 1; fi
+
+CONF=/etc/modprobe.d/disable-algif.conf
+cat >"${CONF}" <<'EOF'
+# Managed file. CVE-2026-31431 mitigation.
+install algif_aead    /bin/false
+install algif_hash    /bin/false
+install algif_skcipher /bin/false
+install algif_rng     /bin/false
+EOF
+chmod 0644 "${CONF}"
+
+for mod in algif_aead algif_hash algif_skcipher algif_rng; do
+    if lsmod | awk '{print $1}' | grep -qx "${mod}"; then
+        rmmod "${mod}" 2>/dev/null || echo "[!] could not unload ${mod}"
+    fi
+done
+
+if command -v update-initramfs >/dev/null 2>&1; then update-initramfs -u || true
+elif command -v dracut >/dev/null 2>&1; then dracut --force || true
+fi
+echo "[+] mitigation applied; reboot recommended."


### PR DESCRIPTION
## Summary

Stages mitigation artifacts for **CVE-2026-31431 ("Copy Fail")** — Linux kernel LPE in `algif_aead`, 4-byte page-cache write, container-escape. Disclosed 2026-04-29.

**This is the highest-blast-radius surface in the org.** NatureOS hosts run Cloud Shell, Functions, sandboxes, notebooks, API Gateway — all multi-tenant or internet-facing. An unpatched node here means a shell tenant or sandbox tenant can become host root and reach into other tenants via the host-wide page cache. The findings report recommends pausing Cloud Shell / sandbox tenants until backing nodes report mitigated.

## What's included

Same bundle as the other org repos plus NatureOS-specific operator guidance in `docs/security/cve-2026-31431-report.md`:
- Bake the modprobe block into the node base image so re-imaged nodes start mitigated.
- Admission webhook to refuse scheduling untrusted workloads onto nodes whose detect-probe failed in the last 5 minutes.
- Cordon + drain any node failing the detect probe.

## Adjacent-issue audit (this repo)

GitHub code search: **0 hits** for `AF_ALG`, `algif`, `splice`/`vmsplice`, `privileged: true`, `hostNetwork/PID/IPC`, `SYS_MODULE`/`CAP_SYS_ADMIN`, `USER root`. No direct application-code exposure, but the **tenant surface** means the seccomp + Falco layers are essential on top of host patching.

## Caveats

- `a664bf3d603d` from disclosure post; **not independently verified** here.
- Kyverno-specific; translate for your admission controller if different.
- Cloud Shell / sandbox tenant pause is an operational decision, not automated by this PR.

## Test plan

- [ ] Mitigation + detect on a staging NatureOS node; reboot; verify mitigated.
- [ ] Ansible dry-run across a staging slice of the fleet.
- [ ] Kyverno policy dry-run; verify a Pod without the seccomp profile is rejected.
- [ ] Seccomp profile distribution to `/var/lib/kubelet/seccomp/` on a staging node.
- [ ] Falco AF_ALG rule verification with a deliberate `socket(AF_ALG)`.
- [ ] Runner pre-check on one self-hosted runner.
- [ ] Verify Cloud Shell / Functions / sandbox nodes are all mitigated before tenant resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FXuz2NPKgVn226KaV58czU)_

## Summary by Sourcery

Stage mitigation artifacts and operational guidance for CVE-2026-31431 across NatureOS hosts, Kubernetes workloads, and CI runners.

New Features:
- Add host-level mitigation and detection scripts to block and verify disabling of algif_* modules for CVE-2026-31431.
- Introduce Kyverno cluster policy and seccomp profile requirement to enforce AF_ALG blocking and restrict host namespaces for Pods.
- Add Falco detection rules to alert on AF_ALG socket creation and splice-based exploitation patterns.
- Provide a reusable GitHub Actions workflow and runner precheck script to refuse jobs on unmitigated self-hosted runners.
- Add an Ansible playbook to roll out persistent algif_* modprobe blocks and record mitigation state on NatureOS hosts.

Documentation:
- Add a security report documenting CVE-2026-31431 impact, mitigation plan, rollout checklist, and hardening recommendations for NatureOS.