### PR TITLE
chore: assert proprietary license + NOTICE + SECURITY policy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,37 @@
+PROPRIETARY SOFTWARE LICENSE
+
+Copyright (c) 2022-2026 Mycosoft, Inc. All Rights Reserved.
+
+This software, including all source code, object code, documentation, designs,
+schematics, data, models, weights, and associated materials (collectively, the
+"Software"), is the proprietary and confidential property of Mycosoft, Inc.
+("Mycosoft") and is protected by United States and international copyright,
+trade secret, and other intellectual property laws.
+
+NO LICENSE GRANTED. No license, right, or permission -- whether express,
+implied, by estoppel, or otherwise -- is granted to any person or entity to
+use, access, copy, reproduce, modify, adapt, translate, merge, publish,
+distribute, sublicense, sell, create derivative works from, reverse engineer,
+decompile, disassemble, or otherwise exploit the Software, in whole or in part,
+without the prior written authorization of Mycosoft, executed by a duly
+authorized officer of Mycosoft.
+
+CONFIDENTIALITY. The Software constitutes the confidential information and
+trade secrets of Mycosoft. Any access to the Software transfers no ownership
+interest whatsoever and imposes an obligation to maintain its confidentiality.
+
+NO WARRANTY. The Software is provided "AS IS," without warranty of any kind,
+express or implied.
+
+EXPORT CONTROL. The Software may be subject to United States export control
+laws and regulations, including the Export Administration Regulations (EAR,
+15 C.F.R. Parts 730-774) and potentially the International Traffic in Arms
+Regulations (ITAR, 22 C.F.R. Parts 120-130). The Software may not be exported,
+re-exported, released, or disclosed to any foreign person or destination except
+in full compliance with such laws. Unauthorized export is strictly prohibited.
+
+ENFORCEMENT. Unauthorized use, reproduction, or distribution of the Software,
+or any portion thereof, may result in severe civil and criminal penalties and
+will be prosecuted to the maximum extent possible under law.
+
+CONTACT. All licensing and authorization inquiries: legal@mycosoft.org

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,12 @@
+Mycosoft, Inc. -- PROPRIETARY AND CONFIDENTIAL
+Copyright (c) 2022-2026 Mycosoft, Inc. All Rights Reserved.
+
+This repository and its contents are the proprietary property of Mycosoft, Inc.
+and are licensed to no third party. All rights reserved. See LICENSE.
+
+Portions of this codebase may relate to marine, acoustic, and environmental
+sensing technologies that could be subject to U.S. export control laws
+(EAR / ITAR). Do not export, share, or disclose outside Mycosoft, Inc. without
+prior written authorization and export-compliance review.
+
+Unauthorized use is prohibited. Contact: legal@mycosoft.org

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Ownership & Access
+All code in this repository is the proprietary and confidential property of
+Mycosoft, Inc. It is licensed to no third party. Unauthorized access, use,
+copying, adaptation, or distribution is prohibited. See LICENSE and NOTICE.
+
+## Export Control Notice
+This repository may contain technical data subject to U.S. export control laws
+(EAR, 15 CFR 730-774; ITAR, 22 CFR 120-130). Access by or transfer to any
+non-U.S. person, or export outside the United States, without prior
+authorization and export-compliance review, is prohibited.
+
+## Handling of Controlled Information
+Parties granted access under a written agreement must handle all materials in
+accordance with that agreement and applicable Mycosoft information-security
+controls, aligned to NIST SP 800-171 where Controlled Unclassified Information
+(CUI) is present.
+
+## Reporting
+Report suspected unauthorized use, access, or a vulnerability to:
+security@mycosoft.org


### PR DESCRIPTION
## Summary
Adds proprietary license and compliance files asserting Mycosoft, Inc. ownership across the repository:
- `LICENSE` — Proprietary Software License (All Rights Reserved), no license granted, export-control (EAR/ITAR) notice.
- `NOTICE` — proprietary/confidential notice with export-control language.
- `SECURITY.md` — security policy covering ownership/access, export control, CUI handling (NIST SP 800-171), and reporting contact.

## Rationale
Company-wide license lockdown sweep to assert proprietary rights and export-compliance posture on all Mycosoft repositories.

## Notes
Files only — no source code changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014VtyQdjDbcFh7Wgq1bzDZ8)_

## Summary by Sourcery

Assert proprietary ownership and security posture by adding licensing, notice, and security policy documents to the repository.

Documentation:
- Add SECURITY policy outlining ownership, export control constraints, handling of controlled information, and security reporting procedures.

Chores:
- Introduce proprietary LICENSE and NOTICE files to formalize Mycosoft, Inc. ownership and confidentiality terms across the repository.